### PR TITLE
chore: update reqwest to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ travis-ci = { repository = "mozilla-services/common-rs" }
 [dependencies]
 lazy_static = "1.0"
 hostname = "0.1"
-reqwest = "0.8"
+reqwest = "0.9"


### PR DESCRIPTION
0.8 depends on an old version of openssl, which is causing some people set-up woe in the `fxa` monorepo.

Ref: mozilla/fxa#1569

@pjenvey r?