### PR TITLE
feat(tracing-actix-web-mozlog): Add crate providing compatibility between Tracing, Actix, and MozLog

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    # Pre-release versions cause false positives in cargo-audit. See https://github.com/RustSec/rustsec-crate/issues/218
+    "RUSTSEC-2018-0019", # False positive on actix-web. Affected versions are <0.7.15, we have 4.0.0-beta.5.
+    "RUSTSEC-2020-0048", # False positive on actix-http. Affected versions are <2.0.0-alpha.1, we have 3.0.0-beta.5.
+]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ workflows:
       - per-crate:
           name: mozsvc-common
           crate: mozsvc-common
+      - per-crate:
+          name: tracing-actix-web-mozlog
+          crate: tracing-actix-web-mozlog
 
 jobs:
   per-crate:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-  "mozsvc-common"
+  "mozsvc-common",
+  "tracing-actix-web-mozlog",
 ]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ A common set of utilities for Mozilla server side applications.
 [crates.io::mozsvc-common]: https://crates.io/crates/mozsvc-common
 [docs::mozsvc-common]: https://docs.rs/mozsvc-common
 [rustdoc-badge::mozsvc-common]: https://img.shields.io/docsrs/mozsvc-common
+
+- [`tracing-actix-web-mozlog`](./tree/master/tracing-actix-web-mozlog)
+  [![version-badge::tracing-actix-web-mozlog]][crates.io::tracing-actix-web-mozlog]
+  [![rustdoc-badge::tracing-actix-web-mozlog]][docs::tracing-actix-web-mozlog]
+
+  Integration between Tracing, Actix, and MozLog.
+
+[version-badge::tracing-actix-web-mozlog]: https://img.shields.io/crates/v/tracing-actix-web-mozlog.svg
+[crates.io::tracing-actix-web-mozlog]: https://crates.io/crates/tracing-actix-web-mozlog
+[docs::tracing-actix-web-mozlog]: https://docs.rs/tracing-actix-web-mozlog
+[rustdoc-badge::tracing-actix-web-mozlog]: https://img.shields.io/docsrs/tracing-actix-web-mozlog

--- a/tracing-actix-web-mozlog/Cargo.toml
+++ b/tracing-actix-web-mozlog/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tracing-actix-web-mozlog"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+chrono = "^0.4"
+gethostname = "^0.2"
+serde = { version = "^1", features = ["derive"] }
+serde_json = "^1"
+tracing = "^0.1"
+tracing-bunyan-formatter = "^0.2"
+tracing-subscriber = "^0.2"
+actix-web = "=4.0.0-beta.5"
+actix-service = "=2.0.0-beta.5"
+actix-http = "=3.0.0-beta.5"
+tracing-actix-web = { version = "=0.4.0-beta.4", default-features = false }
+
+[dev-dependencies]
+maplit = "^1"
+pretty_assertions = "^0.7"
+jsonschema = "^0.9"
+lazy_static = "^1.4"
+actix-rt = "^2.2.0"
+tracing-futures = { version = "^0.2", features = ["std-future"] }

--- a/tracing-actix-web-mozlog/README.md
+++ b/tracing-actix-web-mozlog/README.md
@@ -1,0 +1,22 @@
+# tracing-actix-web-mozlog
+
+[![License: MPL 2.0]][mpl 2.0]
+[![Build Status]][circleci]
+[![version-badge::tracing-actix-web-mozlog]][crates.io::tracing-actix-web-mozlog]
+[![rustdoc-badge::tracing-actix-web-mozlog]][docs::tracing-actix-web-mozlog]
+
+[license: mpl 2.0]: https://img.shields.io/badge/License-MPL%202.0-blue.svg
+[mpl 2.0]: https://opensource.org/licenses/MPL-2.0
+[build status]: https://img.shields.io/circleci/build/github/mozilla-services/common-rs
+[circleci]: https://app.circleci.com/pipelines/github/mozilla-services/common-rs
+
+[version-badge::tracing-actix-web-mozlog]: https://img.shields.io/crates/v/tracing-actix-web-mozlog.svg
+[crates.io::tracing-actix-web-mozlog]: https://crates.io/crates/tracing-actix-web-mozlog
+[docs::tracing-actix-web-mozlog]: https://docs.rs/tracing-actix-web-mozlog
+[rustdoc-badge::tracing-actix-web-mozlog]: https://img.shields.io/docsrs/tracing-actix-web-mozlog
+
+Support for [tracing][] in [actix-web][] apps that target [MozLog][].
+
+[tracing]: https://tracing.rs/tracing/
+[actix-web]: https://actix.rs/
+[MozLog]: https://wiki.mozilla.org/Firefox/Services/Logging

--- a/tracing-actix-web-mozlog/src/lib.rs
+++ b/tracing-actix-web-mozlog/src/lib.rs
@@ -1,0 +1,91 @@
+//! # tracing-actix-web-mozlog
+//!
+//! Support for [tracing] in [actix-web](https://actix.rs/) apps that target [MozLog][].
+//!
+//! [MozLog]: https://wiki.mozilla.org/Firefox/Services/Logging
+//!
+//! This crate provides a Tracing subscriber as well as an Actix web middleware.
+//! Both can be used independently, but using them together implements the full
+//! recommended format for MozLog.
+//!
+//! ## Subscriber
+//!
+//! To use the subscriber, register it and a [`JsonStorageLayer`] with a
+//! [`tracing_subscriber::Registry`]:
+//!
+//! ```
+//! use tracing_actix_web_mozlog::{JsonStorageLayer, MozLogFormatLayer};
+//! use tracing_subscriber::layer::SubscriberExt;
+//!
+//! let subscriber = tracing_subscriber::registry()
+//!     .with(JsonStorageLayer)
+//!     .with(MozLogFormatLayer::new("service-name", std::io::stdout));
+//! ```
+//!
+//! This subscriber can then be registered with tracing using
+//! [`tracing::subscriber::set_global_default`], or any other registration
+//! method. It will manage formatting any events logged in MozLog JSON format.
+//!
+//! Fields defined on the enclosing spans of an event will be included when
+//! logging an event. The event overrides the spans, and inner spans override
+//! outer spans.
+//!
+//! ## Middleware
+//!
+//! To use the middleware, register it while creating your app, as normal:
+//!
+//! ```
+//! use tracing_actix_web_mozlog::MozLogMiddleware;
+//! use actix_web::App;
+//!
+//! App::new()
+//!     .wrap(MozLogMiddleware::new());
+//! ```
+//!
+//! This middleware will emit `request.summary` events for each request as it is
+//! completed, including timing information. For more information about
+//! customizing these events, see [`MozLogMiddleware`]'s documentation.
+//!
+//! ## Message Types
+//!
+//! MozLog expects all messages to have a type that defines the schema of their
+//! fields. This can be specified with the `type` field while logging events.
+//! Since `type` is a Rust reserved keyword, this can also be specified using a
+//! raw-string-inspired format: `r#type = value`.
+//!
+//! ```rust
+//! let format_error = "...";
+//! tracing::warn!(
+//!     r#type = "auth.login.invalid-email",
+//!     %format_error,
+//!     "A user attempted to register using an email in an invalid format"
+//! );
+//! ```
+//!
+//! Messages that don't include a `type` field will be assigned a type of
+//! `<unknown>`. If a message contains both a `type` field and a `r#type` field,
+//! the `type` field will take precedence.
+//!
+//! Notably, use of the standard `log` facade's macros will have an unknown type,
+//! as well as most other logging that originates from libraries.
+//!
+//! ## MozLog extensions
+//!
+//! In addition to all standard MozLog fields, this crate always adds a `spans`
+//! field messages. This contains a comma-separated list of the names of the
+//! spans enclosing the event, with the outermost span coming first. Top-level
+//! events will have an empty string for this value.
+
+#![warn(missing_crate_level_docs)]
+#![warn(missing_docs)]
+
+mod middleware;
+mod subscriber;
+
+pub use crate::middleware::MozLogMiddleware;
+pub use crate::subscriber::{MozLogFormatLayer, MozLogMessage};
+
+/// A layer to collect information about Tracing spans and provide it to other layers.
+///
+/// This is a re-exported entry from [`tracing_bunyan_formatter`].
+pub use tracing_bunyan_formatter::JsonStorageLayer;

--- a/tracing-actix-web-mozlog/src/middleware.rs
+++ b/tracing-actix-web-mozlog/src/middleware.rs
@@ -1,0 +1,87 @@
+//! Loggers for the request/response cycle.
+
+use std::time::Instant;
+
+use actix_web::{dev::ServiceResponse, HttpMessage};
+use tracing::Span;
+use tracing_actix_web::{RequestId, RootSpanBuilder, TracingLogger};
+
+/// Middleware that implements the request/response cycle logging required by MozLog.
+pub type MozLogMiddleware = TracingLogger<MozLogRootSpanBuilder>;
+
+/// A root span builder for tracing_actix_web to customize the extra fields we
+/// log with requests, and to log an event when requests end.
+///
+/// # Examples
+///
+/// ```
+/// use tracing_actix_web_mozlog::MozLogMiddleware;
+/// use actix_web::App;
+/// App::new()
+///     .wrap(MozLogMiddleware::new());
+/// ```
+pub struct MozLogRootSpanBuilder;
+
+struct RequestStart(Instant);
+
+impl RootSpanBuilder for MozLogRootSpanBuilder {
+    fn on_request_start(request: &actix_web::dev::ServiceRequest) -> tracing::Span {
+        let http_method = request.method().as_str();
+
+        let mut request_extensions = request.extensions_mut();
+        let request_id = request_extensions.get::<RequestId>().cloned().unwrap();
+        request_extensions.insert(RequestStart(Instant::now()));
+
+        let span = tracing::info_span!(
+            "request",
+            method = %http_method,
+            path = %request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
+            code = tracing::field::Empty,
+            rid = %request_id,
+            errno = tracing::field::Empty,
+            agent = tracing::field::Empty,
+            msg = tracing::field::Empty,
+            lang = tracing::field::Empty,
+            uid = tracing::field::Empty,
+            t = tracing::field::Empty,
+            t_ns = tracing::field::Empty,
+        );
+
+        if let Some(user_agent) = request.headers().get("User-Agent") {
+            span.record("agent", &user_agent.to_str().unwrap_or("<bad_utf8>"));
+        }
+
+        span
+    }
+
+    fn on_request_end<B>(span: Span, outcome: &Result<ServiceResponse<B>, actix_web::Error>) {
+        match &outcome {
+            Ok(response) => {
+                if let Some(req_start) = response.request().extensions().get::<RequestStart>() {
+                    let elapsed = req_start.0.elapsed();
+                    span.record("t", &(elapsed.as_millis() as u32));
+                    span.record("t_ns", &(elapsed.as_nanos() as u64));
+                }
+
+                if let Some(error) = response.response().error() {
+                    handle_error(span, error);
+                } else {
+                    span.record("code", &response.response().status().as_u16());
+                    response.status();
+                }
+            }
+            Err(error) => handle_error(span, error),
+        };
+
+        tracing::info!(r#type = "request.summary")
+    }
+}
+
+/// Annotate the root request span with information about a request error.
+fn handle_error(span: Span, error: &actix_web::Error) {
+    let response_error = error.as_response_error();
+    let status = response_error.status_code();
+    span.record("errno", &1);
+    span.record("msg", &tracing::field::display(response_error));
+    span.record("code", &status.as_u16());
+}

--- a/tracing-actix-web-mozlog/src/subscriber.rs
+++ b/tracing-actix-web-mozlog/src/subscriber.rs
@@ -1,0 +1,156 @@
+use gethostname::gethostname;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{collections::HashMap, io::Write};
+use tracing::{Event, Level, Subscriber};
+use tracing_bunyan_formatter::JsonStorage;
+use tracing_subscriber::{fmt::MakeWriter, layer::Context};
+
+const MOZLOG_VERSION: &str = "2.0";
+
+/// This layer is exclusively concerned with formatting information using the
+/// [MozLog format](https://wiki.mozilla.org/Firefox/Services/Logging). It relies
+/// on the upstream [`crate::JsonStorageLayer`] to get access
+/// to the fields attached to each span.
+///
+/// # Example
+///
+/// ```
+/// use tracing_actix_web_mozlog::{JsonStorageLayer, MozLogFormatLayer};
+/// use tracing_subscriber::layer::SubscriberExt;
+/// let subscriber = tracing_subscriber::registry()
+///     .with(JsonStorageLayer)
+///     .with(MozLogFormatLayer::new("service-name", std::io::stdout));
+/// ```
+pub struct MozLogFormatLayer<W: MakeWriter + 'static> {
+    name: String,
+    pid: u32,
+    hostname: String,
+    make_writer: W,
+}
+
+/// A logging message in MozLog format, adapted to Tracing.
+#[derive(Clone, Default, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MozLogMessage {
+    /// Number of nanoseconds since the UNIX epoch (which is UTC)
+    pub timestamp: i64,
+
+    /// Type of message i.e. "request.summary"
+    #[serde(rename = "type")]
+    pub message_type: String,
+
+    /// Data source, server that is doing the logging, e.g. “Sync-1_5”
+    pub logger: String,
+
+    /// Hostname that generated the message
+    pub hostname: String,
+
+    /// Envelope version; log format version
+    pub env_version: String,
+
+    /// Process ID that generated the message
+    pub pid: u32,
+
+    /// Syslog severity levels
+    pub severity: u32,
+
+    /// Hash of fields
+    pub fields: HashMap<String, Value>,
+}
+
+impl<W: MakeWriter + 'static> MozLogFormatLayer<W> {
+    /// Create a new moz log subscriber.
+    pub fn new<S: AsRef<str>>(name: S, make_writer: W) -> Self {
+        Self {
+            name: name.as_ref().to_string(),
+            make_writer,
+            pid: std::process::id(),
+            hostname: gethostname().to_string_lossy().into_owned(),
+        }
+    }
+
+    fn emit(&self, mut buffer: Vec<u8>) -> Result<(), std::io::Error> {
+        buffer.write_all(b"\n")?;
+        self.make_writer.make_writer().write_all(&buffer)
+    }
+}
+
+impl<S, W> tracing_subscriber::Layer<S> for MozLogFormatLayer<W>
+where
+    S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    W: MakeWriter + 'static,
+{
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        // Use a closure that returns a `Result` to enable usage of the `?`
+        // operator and make clearer code. This is called immediately below.
+        let make_log_line = || {
+            let mut event_visitor = JsonStorage::default();
+            event.record(&mut event_visitor);
+
+            let mut values: HashMap<String, Value> = event_visitor
+                .values()
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect();
+
+            let spans = {
+                let mut span_names = vec![];
+                let mut current = ctx.lookup_current();
+                while let Some(span) = &current {
+                    {
+                        let ext = span.extensions();
+                        let span_visitor = ext
+                            .get::<JsonStorage>()
+                            .expect("MozLogFormatLayer requires JsonStorage layer");
+                        for (k, v) in span_visitor.values() {
+                            values.entry(k.to_string()).or_insert_with(|| v.clone());
+                        }
+                    }
+
+                    span_names.push(span.name());
+                    current = span.parent();
+                }
+                span_names.reverse();
+                span_names.join(",")
+            };
+
+            // See https://en.wikipedia.org/wiki/Syslog#Severity_levels
+            let severity = match *event.metadata().level() {
+                Level::ERROR => 3, // Syslog Error
+                Level::WARN => 4,  // Syslog Warning
+                Level::INFO => 5,  // Syslog Normal
+                Level::DEBUG => 6, // Syslog Informational
+                Level::TRACE => 7, // Syslog Debug
+            };
+
+            let type_field = values.remove("type");
+            let raw_type_field = values.remove("r#type");
+            values.insert("spans".to_string(), spans.into());
+
+            let v = MozLogMessage {
+                timestamp: chrono::Utc::now().timestamp_nanos(),
+                message_type: type_field
+                    .or(raw_type_field)
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                    .unwrap_or_else(|| "<unknown>".to_string()),
+                logger: self.name.clone(),
+                hostname: self.hostname.clone(),
+                env_version: MOZLOG_VERSION.to_string(),
+                pid: self.pid,
+                severity,
+                fields: values,
+            };
+
+            // If there is an error, just squash it quietly. After all, if we
+            // failed to log, we can't exactly log an error.
+            serde_json::to_vec(&v).map_err(|_| ())
+        };
+
+        let log_line_result: Result<Vec<u8>, ()> = make_log_line();
+        // Discard any errors, since they probably can't be logged anyways.
+        if let Ok(log_line) = log_line_result {
+            let _ = self.emit(log_line);
+        }
+    }
+}

--- a/tracing-actix-web-mozlog/tests/all/main.rs
+++ b/tracing-actix-web-mozlog/tests/all/main.rs
@@ -1,0 +1,4 @@
+mod test_json_schema;
+mod test_middleware;
+mod test_mozlog_fields;
+mod utils;

--- a/tracing-actix-web-mozlog/tests/all/mozlog_schema.json
+++ b/tracing-actix-web-mozlog/tests/all/mozlog_schema.json
@@ -1,0 +1,95 @@
+{
+  "type": "object",
+  "required": ["Timestamp"],
+  "properties": {
+    "Timestamp": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "Type": {
+      "type": "string"
+    },
+    "Logger": {
+      "type": "string"
+    },
+    "Hostname": {
+      "type": "string",
+      "format": "hostname"
+    },
+    "EnvVersion": {
+      "type": "string",
+      "pattern": "^\\d+(?:\\.\\d+){0,2}$"
+    },
+    "Severity": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 7
+    },
+    "Pid": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "Fields": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/field_value"
+          },
+          {
+            "$ref": "#/definitions/field_array"
+          },
+          {
+            "$ref": "#/definitions/field_object"
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "field_value": {
+      "type": ["string", "number", "boolean"]
+    },
+    "field_array": {
+      "type": "array",
+      "minItems": 1,
+      "oneOf": [
+        {
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "items": {
+            "type": "number"
+          }
+        },
+        {
+          "items": {
+            "type": "boolean"
+          }
+        }
+      ]
+    },
+    "field_object": {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/field_value"
+            },
+            {
+              "$ref": "#/definitions/field_array"
+            }
+          ]
+        },
+        "representation": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tracing-actix-web-mozlog/tests/all/test_json_schema.rs
+++ b/tracing-actix-web-mozlog/tests/all/test_json_schema.rs
@@ -1,0 +1,38 @@
+use jsonschema::JSONSchema;
+use lazy_static::lazy_static;
+use serde_json::Value;
+use tracing::{event, span, Level};
+
+use crate::utils::{log_test, LogWatcher};
+
+lazy_static! {
+    static ref MOZLOG_SCHEMA: JSONSchema<'static> =
+        JSONSchema::compile(&PARSED_SCHEMA).expect("schema is in invalid format");
+    static ref PARSED_SCHEMA: Value =
+        serde_json::from_str(include_str!("./mozlog_schema.json")).expect("schema json is invalid");
+}
+
+#[test]
+fn logger_matches_schema() {
+    let mut log_watcher: LogWatcher<Value> = log_test(|| {
+        event!(Level::INFO, "event at nesting 0");
+        let _guard1 = span!(Level::INFO, "test_span_1").entered();
+        event!(Level::INFO, "event at nesting 1");
+        let _guard2 = span!(Level::INFO, "test_span_2").entered();
+        event!(Level::INFO, "event at nesting 2");
+    });
+
+    for event in log_watcher.events() {
+        let errors = match MOZLOG_SCHEMA.validate(event) {
+            Ok(()) => None,
+            Err(errors) => Some(errors.collect::<Vec<_>>()),
+        };
+        if let Some(errors) = &errors {
+            println!("Error while validating event:\n{:#?}", event);
+            for error in errors {
+                println!("Error: {:#?}", error);
+            }
+        }
+        assert!(errors.is_none());
+    }
+}

--- a/tracing-actix-web-mozlog/tests/all/test_middleware.rs
+++ b/tracing-actix-web-mozlog/tests/all/test_middleware.rs
@@ -1,0 +1,144 @@
+use actix_http::ResponseError;
+use actix_service::Service;
+use actix_web::{get, http::StatusCode, test, web, App, HttpResponse};
+use maplit::hashmap;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::fmt::Display;
+
+use crate::utils::{log_test_async, LogWatcher};
+use tracing_actix_web_mozlog::{MozLogMessage, MozLogMiddleware};
+
+#[get("/{status}")]
+async fn handler_status_echo(status: web::Path<u16>) -> HttpResponse {
+    HttpResponse::new(StatusCode::from_u16(*status).expect("invalid status code"))
+}
+
+#[derive(Debug)]
+struct TestError;
+
+impl Display for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "test error")
+    }
+}
+
+impl ResponseError for TestError {}
+
+#[get("/")]
+async fn handler_error() -> Result<HttpResponse, TestError> {
+    Err(TestError)
+}
+
+#[actix_rt::test]
+async fn test_it_logs_requests() {
+    let mut log_watcher: LogWatcher = log_test_async(|| async {
+        let middleware = MozLogMiddleware::new();
+        let app =
+            test::init_service(App::new().wrap(middleware).service(handler_status_echo)).await;
+
+        let req = test::TestRequest::with_uri("/200").to_request();
+        let res = app.call(req).await.expect("request handler error");
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let req = test::TestRequest::with_uri("/400").to_request();
+        let res = app.call(req).await.expect("request handler error");
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+        let req = test::TestRequest::with_uri("/500").to_request();
+        let res = app.call(req).await.expect("request handler error");
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+
+    assert!(
+        log_watcher.has(|event| {
+            event.severity == 5
+                && event.message_type == "request.summary"
+                && event.fields.get("code") == Some(&json!(200))
+        }),
+        "should log successful responses"
+    );
+    assert!(
+        log_watcher.has(|event| {
+            event.severity == 5
+                && event.fields.get("code") == Some(&json!(400))
+                && event.message_type == "request.summary"
+        }),
+        "should log client errors"
+    );
+    assert!(
+        log_watcher.has(|event| {
+            event.severity == 5
+                && event.fields.get("code") == Some(&json!(500))
+                && event.message_type == "request.summary"
+        }),
+        "should log server errors"
+    );
+}
+
+#[actix_rt::test]
+async fn test_request_summary_has_recommended_fields() {
+    let mut log_watcher: LogWatcher = log_test_async(|| async {
+        let middleware = MozLogMiddleware::new();
+        let app =
+            test::init_service(App::new().wrap(middleware).service(handler_status_echo)).await;
+
+        let req = test::TestRequest::with_uri("/200")
+            .append_header(("User-Agent", "A Test Client"))
+            .to_request();
+        let res = app.call(req).await.expect("request handler error");
+        assert_eq!(res.status(), StatusCode::OK);
+    })
+    .await;
+
+    let event = dbg!(log_watcher.events())
+        .iter()
+        .find(|event| event.message_type == "request.summary")
+        .expect("Could not find request.summary event");
+    assert_eq!(
+        *event,
+        MozLogMessage {
+            message_type: "request.summary".into(),
+            logger: "test-logger".into(),
+            env_version: "2.0".into(),
+            severity: 5,
+            fields: hashmap! {
+                "agent".to_string() => json!("A Test Client"),
+                "path".to_string() => json!("/200"),
+                "method".to_string() => json!("GET"),
+                "code".to_string() => json!(200),
+                "spans".to_string() => json!("request"),
+                "rid".to_string() => event.fields.get("rid")
+                    .expect("Should have a request id").clone(),
+                "t".to_string() => event.fields.get("t")
+                    .expect("should have request time in milliseconds").clone(),
+                "t_ns".to_string() => event.fields.get("t_ns")
+                    .expect("should have request time in nanoseconds").clone(),
+            },
+            ..event.clone()
+        },
+        "Should have the expected fields"
+    );
+}
+
+#[actix_rt::test]
+async fn test_it_logs_controlled_errors() {
+    let mut log_watcher: LogWatcher = log_test_async(|| async {
+        let middleware = MozLogMiddleware::new();
+        let app = test::init_service(App::new().wrap(middleware).service(handler_error)).await;
+        let req = test::TestRequest::with_uri("/").to_request();
+        let res = app.call(req).await.expect("request handler error");
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+
+    assert!(
+        log_watcher.has(|event| {
+            event.severity == 5
+                && event.message_type == "request.summary"
+                && event.fields.get("code") == Some(&json!(500))
+        }),
+        "errors are still logged with INFO level request.summary"
+    );
+}

--- a/tracing-actix-web-mozlog/tests/all/test_mozlog_fields.rs
+++ b/tracing-actix-web-mozlog/tests/all/test_mozlog_fields.rs
@@ -1,0 +1,195 @@
+use crate::utils::{log_test, LogWatcher};
+use maplit::hashmap;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tracing::{event, span, Level};
+use tracing_actix_web_mozlog::MozLogMessage;
+
+#[test]
+fn test_format() {
+    let mut log_watcher: LogWatcher<MozLogMessage> = log_test(|| {
+        event!(
+            Level::INFO,
+            r#type = "test",
+            "simple event without a parent span"
+        );
+    });
+
+    let events = log_watcher.events();
+
+    assert!(!events.is_empty(), "There should be at least one event");
+    assert_eq!(
+        events,
+        &vec![MozLogMessage {
+            message_type: "test".to_string(),
+            logger: "test-logger".to_string(),
+            env_version: "2.0".to_string(),
+            severity: 5,
+            fields: hashmap!(
+                "message".to_string() => "simple event without a parent span".into(),
+                "spans".to_string() => "".into(),
+            ),
+            ..events[0].clone()
+        }]
+    );
+
+    assert!(events[0].pid > 0, "Should have a positive PID");
+    assert_ne!(events[0].hostname, "", "Should have a non-empty hostname");
+
+    // Trying to assert that the timestamp is exactly right is going to be
+    // difficult. Instead this tests that it is the right order of magnitude. To
+    // do this we interpret it as nanoseconds 1x10-9, as given in the spec, and
+    // then check that it is a time that occurs roughly sometime this century.
+    // If the given number was in milliseconds, seconds, or any other order of
+    // magnitude, the below would fail. Gigaseconds are 1x10^9 seconds. 1
+    // gigaseconds since epoch is sometime in the year 2001, and 4 gigaseconds
+    // is in 2096.
+    let gigaseconds = events[0].timestamp / i64::pow(10, 18);
+    assert!(
+        (1..=4).contains(&gigaseconds),
+        "Should have a timestamp in this century"
+    );
+}
+
+#[test]
+fn test_log_level_to_severity() {
+    let mut log_watcher: LogWatcher<MozLogMessage> = log_test(|| {
+        event!(Level::ERROR, "error");
+        event!(Level::WARN, "warn");
+        event!(Level::INFO, "info");
+        event!(Level::DEBUG, "debug");
+        event!(Level::TRACE, "trace");
+    });
+
+    log_watcher.has(|msg| {
+        msg.fields.get("msg") == Some(&json!("error"))
+            && msg.fields.get("severity") == Some(&json!(3))
+    });
+    log_watcher.has(|msg| {
+        msg.fields.get("msg") == Some(&json!("warn"))
+            && msg.fields.get("severity") == Some(&json!(4))
+    });
+    log_watcher.has(|msg| {
+        msg.fields.get("msg") == Some(&json!("info"))
+            && msg.fields.get("severity") == Some(&json!(5))
+    });
+    log_watcher.has(|msg| {
+        msg.fields.get("msg") == Some(&json!("debug"))
+            && msg.fields.get("severity") == Some(&json!(6))
+    });
+    log_watcher.has(|msg| {
+        msg.fields.get("msg") == Some(&json!("trace"))
+            && msg.fields.get("severity") == Some(&json!(7))
+    });
+}
+
+#[test]
+fn test_span_is_listed() {
+    let mut log_watcher: LogWatcher = log_test(|| {
+        let span = span!(Level::INFO, "test_span");
+        let _guard = span.enter();
+        event!(Level::INFO, "test_event");
+    });
+
+    let events = log_watcher.events();
+    assert!(!events.is_empty());
+
+    assert_eq!(
+        events,
+        &vec![MozLogMessage {
+            fields: hashmap!(
+                "message".to_string() => "test_event".into(),
+                "spans".to_string() => "test_span".into(),
+            ),
+            ..events[0].clone()
+        }]
+    );
+}
+
+#[test]
+fn test_nested_spans() {
+    let mut log_watcher: LogWatcher = log_test(|| {
+        event!(Level::INFO, "event at nesting 0");
+        let _guard1 = span!(Level::INFO, "test_span_1").entered();
+        event!(Level::INFO, "event at nesting 1");
+        let _guard2 = span!(Level::INFO, "test_span_2").entered();
+        event!(Level::INFO, "event at nesting 2");
+    });
+
+    let events = log_watcher.events();
+    assert!(!events.is_empty());
+
+    assert_eq!(
+        events,
+        &vec![
+            MozLogMessage {
+                fields: hashmap!(
+                    "message".to_string() => "event at nesting 0".into(),
+                    "spans".to_string() => "".into(),
+                ),
+                ..events[0].clone()
+            },
+            MozLogMessage {
+                fields: hashmap!(
+                    "message".to_string() => "event at nesting 1".into(),
+                    "spans".to_string() => "test_span_1".into(),
+                ),
+                ..events[1].clone()
+            },
+            MozLogMessage {
+                fields: hashmap!(
+                    "message".to_string() => "event at nesting 2".into(),
+                    "spans".to_string() => "test_span_1,test_span_2".into(),
+                ),
+                ..events[2].clone()
+            }
+        ]
+    );
+}
+
+#[test]
+fn events_inherit_fields() {
+    let mut log_watcher: LogWatcher = log_test(|| {
+        let _guard = span!(Level::INFO, "test_span", color = "red").entered();
+        event!(Level::INFO, "test_event");
+    });
+    let events = log_watcher.events();
+    assert!(!events.is_empty());
+
+    assert_eq!(
+        events,
+        &vec![MozLogMessage {
+            fields: hashmap!(
+                "message".to_string() => "test_event".into(),
+                "spans".to_string() => "test_span".into(),
+                "color".to_string() => "red".into(),
+            ),
+            ..events[0].clone()
+        }]
+    );
+}
+
+#[test]
+fn innermost_value_wins() {
+    let mut log_watcher: LogWatcher = log_test(|| {
+        let _outer = span!(Level::INFO, "outer", a = 1, b = 1, c = 1).entered();
+        let _inner = span!(Level::INFO, "inner", b = 2, c = 2).entered();
+        event!(Level::INFO, c = 3, "test_event");
+    });
+    let events = log_watcher.events();
+    assert!(!events.is_empty());
+
+    assert_eq!(
+        events,
+        &vec![MozLogMessage {
+            fields: hashmap!(
+                "message".to_string() => "test_event".into(),
+                "spans".to_string() => "outer,inner".into(),
+                "a".to_string() => 1.into(),
+                "b".to_string() => 2.into(),
+                "c".to_string() => 3.into(),
+            ),
+            ..events[0].clone()
+        }]
+    );
+}

--- a/tracing-actix-web-mozlog/tests/all/utils.rs
+++ b/tracing-actix-web-mozlog/tests/all/utils.rs
@@ -1,0 +1,189 @@
+//! Testing utils
+
+use serde::de::DeserializeOwned;
+use std::{
+    future::Future,
+    io::Write,
+    sync::{Arc, Mutex},
+};
+use tracing::Subscriber;
+use tracing_actix_web_mozlog::{JsonStorageLayer, MozLogFormatLayer, MozLogMessage};
+use tracing_futures::WithSubscriber;
+use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt, Registry};
+
+/// Run a closure in an environment configured to use [`MozLogLayer`], and return
+/// a log watcher that cna make assertions about the tracing logs that occurred
+/// while running the closure.
+pub fn log_test<E, F>(test_inner: F) -> LogWatcher<E>
+where
+    E: 'static,
+    E: DeserializeOwned,
+    E: Default,
+    F: FnOnce(),
+{
+    let (log_watcher, subscriber) = make_test_subscriber();
+    tracing::subscriber::with_default(subscriber, test_inner);
+    log_watcher
+}
+
+/// A version of [`log_test`] that can handle async inner tests.
+pub async fn log_test_async<E, F, Fut>(test_inner: F) -> LogWatcher<E>
+where
+    E: 'static,
+    E: DeserializeOwned,
+    E: Default,
+    F: FnOnce() -> Fut,
+    Fut: Future,
+{
+    let (log_watcher, subscriber) = make_test_subscriber();
+    test_inner().with_subscriber(subscriber).await;
+    log_watcher
+}
+
+fn make_test_subscriber<E: Default>() -> (LogWatcher<E>, impl Subscriber) {
+    let log_watcher: LogWatcher<E> = LogWatcher::default();
+    let log_watcher_writer = log_watcher.make_writer();
+    let formatting_layer =
+        MozLogFormatLayer::new("test-logger", move || log_watcher_writer.clone());
+
+    let subscriber = Registry::default()
+        .with(JsonStorageLayer)
+        .with(formatting_layer);
+
+    (log_watcher, subscriber)
+}
+
+/// Helper to collect events emitted by Tracing and later make assertions about
+/// the collected events.
+///
+/// The type parameter `E` is the message type that will be deserialized from the
+/// bytes emitted by Tracing.
+#[derive(Default)]
+pub struct LogWatcher<E = MozLogMessage> {
+    /// The raw bytes received from Tracing. Should represent new-line separated JSON objects.
+    buf: Arc<Mutex<Vec<u8>>>,
+
+    /// Events serialized from [`buf`](Self::buf). As valid JSON objects are
+    /// parsed from `buf`, the corresponding bytes are removed from `buf`. This
+    /// way if there are any partial writes, only the complete objects are
+    /// processed from the buffer, leaving incomplete objects in place.
+    events: Vec<E>,
+}
+
+impl<E> LogWatcher<E> {
+    /// Make a new LogWatcher with some events pre-populated. For testing LogWatcher itself.
+    #[allow(dead_code)]
+    fn with_events(events: Vec<E>) -> Self {
+        Self {
+            events,
+            buf: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl<E> LogWatcher<E>
+where
+    E: DeserializeOwned,
+    E: 'static,
+{
+    /// Test if any event this logger received matches `predicate`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use crate::utils::{LogWatcher, TracingJsonEvent};
+    /// # use std::sync::{Arc, Mutex};
+    /// # use tracing::Level;
+    /// # let mut log_watcher = LogWatcher::with_events(vec![
+    /// #     TracingJsonEvent {
+    /// #         fields: maplit::hashmap!{ "message".to_string() => serde_json::json!("request success") },
+    /// #         level: Level::INFO,
+    /// #         target: String::new(),
+    /// #         timestamp: String::new(),
+    /// #     }
+    /// # ]);
+    /// #
+    /// assert!(log_watcher.has(|msg| msg.field_contains("message", "request success")));
+    /// ```
+    pub fn has<F>(&mut self, predicate: F) -> bool
+    where
+        F: FnMut(&E) -> bool,
+    {
+        self.convert_events();
+        self.events.iter().any(predicate)
+    }
+
+    pub fn events(&mut self) -> &Vec<E> {
+        self.convert_events();
+        &self.events
+    }
+
+    /// Iterate through `self.buf` to convert newline separated, completed J;SON
+    /// objects into [`TracingJsonEvent`] instances that are placed in
+    /// `self.events`.
+    fn convert_events(&mut self) {
+        let mut buf = self.buf.lock().expect("mutex was poisoned");
+        let mut log_text = String::from_utf8(buf.clone()).expect("bad utf8");
+
+        // Repeatedly find the next newline char...
+        while let Some(idx) = log_text.find('\n') {
+            // Split the string at that point...
+            let mut message_json = log_text.split_off(idx);
+            // and keep the left side, and return the right side to the string
+            std::mem::swap(&mut message_json, &mut log_text);
+            // Remove the leading newline that is left on the log line
+            assert_eq!(log_text.chars().next(), Some('\n'));
+            log_text.remove(0);
+
+            // Skip blank lines
+            if message_json.trim().is_empty() {
+                continue;
+            }
+
+            // Now `message_join` contains the first line of logs, and `log_text` contains the rest.
+            let message: E = serde_json::from_str(&message_json)
+                .unwrap_or_else(|_| panic!("Bad JSON in log line: {}", &message_json));
+            self.events.push(message);
+        }
+
+        // Now put the rest of the text back into the buffer.
+        *buf = log_text.into_bytes();
+        // and the mutex unlocks when it drops at the end of the function.
+    }
+}
+
+impl<E> MakeWriter for LogWatcher<E> {
+    type Writer = LogWatcherWriter;
+
+    fn make_writer(&self) -> Self::Writer {
+        LogWatcherWriter {
+            buf: self.buf.clone(),
+        }
+    }
+}
+
+/// A helper that collects log events emitted from Tracing.
+///
+/// This is needed because Tracing consumes its subscribers. This type is a
+/// "scout" that is split off from the main [`LogWatcher`] to give to Tracing,
+/// and the data is written back to the parent type.
+#[derive(Clone)]
+pub struct LogWatcherWriter {
+    /// The handle to the parent log watcher's buffer.
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for LogWatcherWriter {
+    fn write(&mut self, new_bytes: &[u8]) -> std::io::Result<usize> {
+        let mut buf = self
+            .buf
+            .lock()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        buf.extend(new_bytes.iter());
+        Ok(new_bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This verbosely named crate provides everything needed to make a Actix Web
project using Tracing MozLog compatible, both in it's log format, and its
request logging.
