### PR TITLE
feat(tracing-actix-web-mozlog): automatically apply the correct Tracing subscriber to handlers

### DIFF
--- a/tracing-actix-web-mozlog/CHANGELOG.md
+++ b/tracing-actix-web-mozlog/CHANGELOG.md
@@ -1,0 +1,16 @@
+<a name="v0.2"></a>
+## v0.2 (2021-06-08)
+
+### Breaking Changes
+
+* `MozLog` middleware must now be created outside of the `HttpServer::new` worker factory closure. ([306452e1](https://github.com/mozilla-services/common-rs/commit/306452e1ada47cbe2f0991afd0113289902a8803)
+
+### Features
+
+* Automatically apply the correct Tracing subscriber to handlers. ([306452e1](https://github.com/mozilla-services/common-rs/commit/306452e1ada47cbe2f0991afd0113289902a8803)
+
+
+<a name="v0.1"></a>
+## v0.1 (2021-06-02)
+
+Initial release

--- a/tracing-actix-web-mozlog/Cargo.toml
+++ b/tracing-actix-web-mozlog/Cargo.toml
@@ -20,6 +20,8 @@ actix-web = "=4.0.0-beta.5"
 actix-service = "=2.0.0-beta.5"
 actix-http = "=3.0.0-beta.5"
 tracing-actix-web = { version = "=0.4.0-beta.4", default-features = false }
+futures-util = "^0.3"
+tracing-futures = { version = "^0.2", features = ["std-future"] }
 
 [dev-dependencies]
 maplit = "^1"
@@ -27,4 +29,3 @@ pretty_assertions = "^0.7"
 jsonschema = "^0.9"
 lazy_static = "^1.4"
 actix-rt = "^2.2.0"
-tracing-futures = { version = "^0.2", features = ["std-future"] }

--- a/tracing-actix-web-mozlog/Cargo.toml
+++ b/tracing-actix-web-mozlog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tracing-actix-web-mozlog"
 description = "Support for tracing in actix-web apps that target Mozilla's MozLog"
 license = "MPL-2.0"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 documentation = "https://docs.rs/tracing-actix-web-mozlog"
 repository = "https://github.com/mozilla-services/common-rs"

--- a/tracing-actix-web-mozlog/src/lib.rs
+++ b/tracing-actix-web-mozlog/src/lib.rs
@@ -32,19 +32,23 @@
 //!
 //! ## Middleware
 //!
-//! To use the middleware, register it while creating your app, as normal:
+//! To make sure that the correct Tracing context is captured, it is important to
+//! create the MozLog middleware outside of the `HttpServer::new` closure:
 //!
 //! ```
-//! use tracing_actix_web_mozlog::MozLogMiddleware;
-//! use actix_web::App;
+//! use tracing_actix_web_mozlog::MozLog;
+//! use actix_web::{HttpServer, App};
 //!
-//! App::new()
-//!     .wrap(MozLogMiddleware::new());
+//! let moz_log = MozLog::default();
+//!
+//! let server = HttpServer::new(move || {
+//!     App::new()
+//!         .wrap(moz_log.clone())
+//! });
 //! ```
 //!
 //! This middleware will emit `request.summary` events for each request as it is
-//! completed, including timing information. For more information about
-//! customizing these events, see [`MozLogMiddleware`]'s documentation.
+//! completed, including timing information.
 //!
 //! ## Message Types
 //!
@@ -72,7 +76,7 @@
 //! ## MozLog extensions
 //!
 //! In addition to all standard MozLog fields, this crate always adds a `spans`
-//! field messages. This contains a comma-separated list of the names of the
+//! field to messages. This contains a comma-separated list of the names of the
 //! spans enclosing the event, with the outermost span coming first. Top-level
 //! events will have an empty string for this value.
 
@@ -82,7 +86,7 @@
 mod middleware;
 mod subscriber;
 
-pub use crate::middleware::MozLogMiddleware;
+pub use crate::middleware::MozLog;
 pub use crate::subscriber::{MozLogFormatLayer, MozLogMessage};
 
 /// A layer to collect information about Tracing spans and provide it to other layers.

--- a/tracing-actix-web-mozlog/tests/all/test_middleware.rs
+++ b/tracing-actix-web-mozlog/tests/all/test_middleware.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use std::fmt::Display;
 
 use crate::utils::{log_test_async, LogWatcher};
-use tracing_actix_web_mozlog::{MozLogMessage, MozLogMiddleware};
+use tracing_actix_web_mozlog::{MozLog, MozLogMessage};
 
 #[get("/{status}")]
 async fn handler_status_echo(status: web::Path<u16>) -> HttpResponse {
@@ -33,7 +33,7 @@ async fn handler_error() -> Result<HttpResponse, TestError> {
 #[actix_rt::test]
 async fn test_it_logs_requests() {
     let mut log_watcher: LogWatcher = log_test_async(|| async {
-        let middleware = MozLogMiddleware::new();
+        let middleware = MozLog::default();
         let app =
             test::init_service(App::new().wrap(middleware).service(handler_status_echo)).await;
 
@@ -80,7 +80,7 @@ async fn test_it_logs_requests() {
 #[actix_rt::test]
 async fn test_request_summary_has_recommended_fields() {
     let mut log_watcher: LogWatcher = log_test_async(|| async {
-        let middleware = MozLogMiddleware::new();
+        let middleware = MozLog::default();
         let app =
             test::init_service(App::new().wrap(middleware).service(handler_status_echo)).await;
 
@@ -125,7 +125,7 @@ async fn test_request_summary_has_recommended_fields() {
 #[actix_rt::test]
 async fn test_it_logs_controlled_errors() {
     let mut log_watcher: LogWatcher = log_test_async(|| async {
-        let middleware = MozLogMiddleware::new();
+        let middleware = MozLog::default();
         let app = test::init_service(App::new().wrap(middleware).service(handler_error)).await;
         let req = test::TestRequest::with_uri("/").to_request();
         let res = app.call(req).await.expect("request handler error");


### PR DESCRIPTION
  When the middleware is created, it will now capture the currently active Tracing `Dispatch`. It will then re-apply that `Dispatch` during every request/response cycle. This is important in situations that don't use the global Tracing subscriber, such as tests.
