### PR TITLE
chore(tracing-actix-web-mozlog): v0.3

### DIFF
--- a/tracing-actix-web-mozlog/CHANGELOG.md
+++ b/tracing-actix-web-mozlog/CHANGELOG.md
@@ -1,16 +1,28 @@
+<a name="v0.3"></a>
+
+## v0.3 (2021-07-23)
+
+### Breaking Changes
+
+- Update `actix-web` to `=4.0.0-beta.8`.
+
 <a name="v0.2"></a>
+
 ## v0.2 (2021-06-08)
 
 ### Breaking Changes
 
-* `MozLog` middleware must now be created outside of the `HttpServer::new` worker factory closure. ([306452e1](https://github.com/mozilla-services/common-rs/commit/306452e1ada47cbe2f0991afd0113289902a8803)
+- `MozLog` middleware must now be created outside of the `HttpServer::new`
+  worker factory closure.
+  ([306452e1](https://github.com/mozilla-services/common-rs/commit/306452e1ada47cbe2f0991afd0113289902a8803)
 
 ### Features
 
-* Automatically apply the correct Tracing subscriber to handlers. ([306452e1](https://github.com/mozilla-services/common-rs/commit/306452e1ada47cbe2f0991afd0113289902a8803)
-
+- Automatically apply the correct Tracing subscriber to handlers.
+  ([306452e1](https://github.com/mozilla-services/common-rs/commit/306452e1ada47cbe2f0991afd0113289902a8803)
 
 <a name="v0.1"></a>
+
 ## v0.1 (2021-06-02)
 
 Initial release

--- a/tracing-actix-web-mozlog/Cargo.toml
+++ b/tracing-actix-web-mozlog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tracing-actix-web-mozlog"
 description = "Support for tracing in actix-web apps that target Mozilla's MozLog"
 license = "MPL-2.0"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 documentation = "https://docs.rs/tracing-actix-web-mozlog"
 repository = "https://github.com/mozilla-services/common-rs"


### PR DESCRIPTION
I'm trying to keep up on the latest beta as best I can so that the eventual swith to the non-beta version of actix-web 4.0 will be easier.
