### PR TITLE
fix: handle more x-forwarded-for formats

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,8 @@ ignore = [
     # Pre-release versions cause false positives in cargo-audit. See https://github.com/RustSec/rustsec-crate/issues/218
     "RUSTSEC-2018-0019", # False positive on actix-web. Affected versions are <0.7.15, we have 4.0.0-beta.5.
     "RUSTSEC-2020-0048", # False positive on actix-http. Affected versions are <2.0.0-alpha.1, we have 3.0.0-beta.5.
+
+    # Hyper issues: only used via reqwest (client only)
+    "RUSTSEC-2021-0078", # Only affects hyper server
+    "RUSTSEC-2021-0079", # Unlikely to affect reqwest client requests
 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,4 +58,5 @@ jobs:
       - checkout
       - run:
           name: Cargo audit
-          command: cargo audit
+          # RUSTSEC-2021-0078/79 unlikely to affect clients
+          command: cargo audit --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,5 +58,4 @@ jobs:
       - checkout
       - run:
           name: Cargo audit
-          # RUSTSEC-2021-0078/79 unlikely to affect clients
-          command: cargo audit --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079
+          command: cargo audit


### PR DESCRIPTION
comma separated list of addresses and port numbers

and ignore new hyper RUSTSECs

Closes #19