### PR TITLE
fix(tracing-actix-web-mozlog): Stop including query strings in `path` field

### DIFF
--- a/tracing-actix-web-mozlog/src/middleware.rs
+++ b/tracing-actix-web-mozlog/src/middleware.rs
@@ -158,7 +158,7 @@ impl RootSpanBuilder for MozLogRootSpanBuilder {
         let span = tracing::info_span!(
             "request",
             method = %http_method,
-            path = %request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
+            path = %request.uri().path(),
             code = tracing::field::Empty,
             rid = %request_id,
             errno = tracing::field::Empty,


### PR DESCRIPTION
I noticed this while going through Merino's logs. It will certainly be a problem there. I also think it's generally not what we want for Mozlog compatibility.
