### PR TITLE
chore: add rustsec exceptions to unblock CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,7 +4,15 @@ ignore = [
     "RUSTSEC-2018-0019", # False positive on actix-web. Affected versions are <0.7.15, we have 4.0.0-beta.5.
     "RUSTSEC-2020-0048", # False positive on actix-http. Affected versions are <2.0.0-alpha.1, we have 3.0.0-beta.5.
 
+    # Actix pull in a specific version of the time crate. Unfortunately
+    # we are restricted about which version to use.
+    "RUSTSEC-2020-0071", # Time 0.143 - Potential segfault in time crate.
+
     # Hyper issues: only used via reqwest (client only)
     "RUSTSEC-2021-0078", # Only affects hyper server
     "RUSTSEC-2021-0079", # Unlikely to affect reqwest client requests
+
+    # While this is not a false positive, there is no recommended fix right
+    # now for the chrono problem, hence the exception.
+    "RUSTSEC-2020-0159", # Chrono 0.4.19 - Potential segfault in `localtime_r` invokations.
 ]


### PR DESCRIPTION
I noticed that CI on the master branch was failing because of the audit. This PR was created under the assumption that the same reasoning highlighted in mozilla-services/merino#175 applies here. 