### PR TITLE
fix: correct module import path for maxmind/actix-web-v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
       - checkout
       - run:
           name: Clippy
-          command: cargo hack --each-feature clippy -p << parameters.crate >>
+          command: cargo hack --feature-powerset clippy -p << parameters.crate >>
       - run:
           name: Cargo build
-          command: cargo hack --each-feature build -p << parameters.crate >>
+          command: cargo hack --feature-powerset build -p << parameters.crate >>
       - run:
           name: Cargo test
-          command: cargo hack --each-feature test -p << parameters.crate >> --verbose
+          command: cargo hack --feature-powerset test -p << parameters.crate >> --verbose
       - run:
           name: Cargo Doc
           command: cargo doc -p << parameters.crate >> --all-features

--- a/actix-web-location/src/providers.rs
+++ b/actix-web-location/src/providers.rs
@@ -89,7 +89,7 @@ mod maxmind {
     use actix_web_3::{http::HeaderName, HttpRequest};
 
     #[cfg(feature = "actix-web-v4")]
-    use actix_web_4::{http::HeaderName, HttpRequest};
+    use actix_web_4::{http::header::HeaderName, HttpRequest};
 
     lazy_static! {
         static ref X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");


### PR DESCRIPTION
There was a compile error that wasn't caught by CI. As of right now, I think CI only checks compilation with each feature individually but not combinations of features, and this particular error only occurs when compiling with _both_ the `maxmind` and `actix-web-v4` features.