### PR TITLE
Tag versions with reduced actix-web transitive dependencies

### DIFF
--- a/actix-web-location/CHANGELOG.md
+++ b/actix-web-location/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="0.5.1"></a>
+
+## 0.5.1 (2022-01-11)
+
+- reduce transitive actix-web dependencies
+
 <a name="0.5"></a>
 
 ## 0.5 (2021-12-21)

--- a/actix-web-location/Cargo.toml
+++ b/actix-web-location/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-location"
-version = "0.5.0"
+version = "0.5.1"
 description = "A extensible crate to provide location determination for actix-web, using GeoIP or other techniques"
 license = "MPL-2.0"
 edition = "2018"

--- a/tracing-actix-web-mozlog/CHANGELOG.md
+++ b/tracing-actix-web-mozlog/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="0.4.1"></a>
+
+## 0.4.1 (2022-01-11)
+
+- reduce transitive actix-web dependencies
+
 <a name="v0.4"></a>
 
 ## v0.4 (2021-12-21)

--- a/tracing-actix-web-mozlog/Cargo.toml
+++ b/tracing-actix-web-mozlog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tracing-actix-web-mozlog"
 description = "Support for tracing in actix-web apps that target Mozilla's MozLog"
 license = "MPL-2.0"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 documentation = "https://docs.rs/tracing-actix-web-mozlog"
 repository = "https://github.com/mozilla-services/common-rs"


### PR DESCRIPTION
- chore(actix-web-location): tag v0.5.1
- chore(tracing-actix-web-mozlog): tag v0.4.1
