### PR TITLE
Upgrade reqwest and clean-out additional audit exceptions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,13 +1,5 @@
 [advisories]
 ignore = [
-    # Pre-release versions cause false positives in cargo-audit. See https://github.com/RustSec/rustsec-crate/issues/218
-    "RUSTSEC-2018-0019", # False positive on actix-web. Affected versions are <0.7.15, we have 4.0.0-beta.5.
-    "RUSTSEC-2020-0048", # False positive on actix-http. Affected versions are <2.0.0-alpha.1, we have 3.0.0-beta.5.
-
-    # Hyper issues: only used via reqwest (client only)
-    "RUSTSEC-2021-0078", # Only affects hyper server
-    "RUSTSEC-2021-0079", # Unlikely to affect reqwest client requests
-
     # Older versions of Tokio are vulnerable to a race condition when using oneshot channels.
     # This repository doesn't use oneshot channels, so we are not vulnerable.
     "RUSTSEC-2021-0124", # Tokio 0.1.22 and 0.2.25 - Potential data race.

--- a/mozsvc-common/Cargo.toml
+++ b/mozsvc-common/Cargo.toml
@@ -14,4 +14,4 @@ travis-ci = { repository = "mozilla-services/common-rs" }
 [dependencies]
 lazy_static = "1.0"
 hostname = "0.3"
-reqwest = "0.9" # 0.10+ switches to async call for .send()
+reqwest = "0.11"

--- a/mozsvc-common/src/aws.rs
+++ b/mozsvc-common/src/aws.rs
@@ -15,7 +15,7 @@ pub fn get_ec2_instance_id() -> Option<&'static str> {
 }
 
 fn _get_ec2_instance_id() -> reqwest::Result<String> {
-    let client = reqwest::Client::builder()
+    let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(1))
         .build()?;
     client


### PR DESCRIPTION
This is a follow-on to #41. I had prematurely removed the audit.toml line about time as there was another dependency in the  reqwest tree.

This updates reqwest to 0.11+ and uses the new reqwest blocking Client to keep the `mozsvc-common/src/aws.rs` code from needing to be async.