### PR TITLE
fix: have with_metrics take an Arc<dyn CountedExt>

### DIFF
--- a/actix-web-location/Cargo.toml
+++ b/actix-web-location/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1"
 async-trait = "0.1"
 lazy_static = "1"
 maxminddb = { version = "0.22", optional = true}
-cadence = { version = "0.28", optional = true}
+cadence = { version = "0.29", optional = true}
 
 [features]
 maxmind = ["maxminddb"]

--- a/actix-web-location/src/extractors.rs
+++ b/actix-web-location/src/extractors.rs
@@ -102,7 +102,7 @@ pub struct LocationConfig {
 
     /// An optional sink to send metrics to.
     #[cfg(feature = "cadence")]
-    metrics: Arc<Option<Box<dyn cadence::CountedExt + Send + Sync>>>,
+    metrics: Option<Arc<dyn cadence::CountedExt + Send + Sync>>,
 }
 
 lazy_static! {
@@ -120,9 +120,9 @@ impl LocationConfig {
     #[cfg(feature = "cadence")]
     pub fn with_metrics<M: cadence::CountedExt + Send + Sync + 'static>(
         mut self,
-        metrics: M,
+        metrics: Arc<M>,
     ) -> Self {
-        self.metrics = Arc::new(Some(Box::new(metrics)));
+        self.metrics = Some(metrics);
         self
     }
 


### PR DESCRIPTION
as we'll likely share a single StatsdClient between Location lookup
and other things on separate threads

Closes #47